### PR TITLE
Remove unused imports

### DIFF
--- a/hview.py
+++ b/hview.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 # hview.py — realtime heap flamegraph (bytes-live per call-stack)
 
-import argparse, curses, signal, time, sys, os, hashlib, subprocess, pathlib
-from bcc import BPF, PerfType, PerfSWConfig  # only for constants
+import argparse
+import curses
+import signal
+import time
+import sys
+import hashlib
+from bcc import BPF
 
 # ───── CLI ──────────────────────────────────────────────────────────
 ap = argparse.ArgumentParser(description="Realtime heap flame graph via eBPF")

--- a/sysview.py
+++ b/sysview.py
@@ -4,10 +4,7 @@ import argparse
 import collections
 import datetime
 import json
-import math
 import os
-import signal
-import sys
 import time
 
 from bcc import BPF


### PR DESCRIPTION
## Summary
- remove unused imports in `sysview.py` and `hview.py`
- ensure no F401 warnings remain

## Testing
- `flake8 | grep F401`

------
https://chatgpt.com/codex/tasks/task_e_683f4d1bd8ac83289ab2a150ea795a53