### PR TITLE
Fix hview imports and guard main

### DIFF
--- a/hview.py
+++ b/hview.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 # hview.py — realtime heap flamegraph (bytes-live per call-stack)
 
-import argparse, curses, signal, time, sys, os, hashlib, subprocess, pathlib
-from bcc import BPF, PerfType, PerfSWConfig  # only for constants
+import argparse
+import curses
+import signal
+import time
+import sys
+import hashlib
+from bcc import BPF
 
 # ───── CLI ──────────────────────────────────────────────────────────
 ap = argparse.ArgumentParser(description="Realtime heap flame graph via eBPF")
@@ -201,5 +206,6 @@ def tui(scr):
         time.sleep(0.03)
 
 
-signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
-curses.wrapper(tui)
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+    curses.wrapper(tui)


### PR DESCRIPTION
## Summary
- clean up imports in `hview.py` to only include used modules
- remove unused BCC constants
- run the curses entrypoint only under `__main__`

## Testing
- `python3 -m py_compile hview.py`
- `python3 -m py_compile csview.py sysview.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4d1b2ae4832881800a47d9dbe0f2