### PR TITLE
Add pytest tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,12 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 3. Commit your changes (`git commit -m 'Add some amazing feature'`)
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
+
+## Running Tests
+
+Install pytest and run the test suite from the repository root:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/test_bpf_generation.py
+++ b/tests/test_bpf_generation.py
@@ -1,0 +1,32 @@
+import types, sys
+
+# Stub bcc module to avoid dependency on BCC during import
+bcc_stub = types.ModuleType('bcc')
+bcc_stub.BPF = object
+sys.modules.setdefault('bcc', bcc_stub)
+
+import sysview
+
+
+def _create_monitor(cfg):
+    monitor = sysview.SyscallMonitor.__new__(sysview.SyscallMonitor)
+    monitor.config = cfg
+    return monitor
+
+
+def test_generate_bpf_program_only_enabled_syscalls():
+    cfg = sysview.SyscallConfig()
+    # Disable all syscalls except 'read'
+    for name in cfg.syscalls:
+        cfg.syscalls[name]['enabled'] = (name == 'read')
+
+    monitor = _create_monitor(cfg)
+    program = sysview.SyscallMonitor.generate_bpf_program(monitor)
+
+    # Should contain BPF map and function for 'read'
+    assert 'BPF_HASH(read_count' in program
+    assert 'trace_read_entry' in program
+
+    # Disabled syscalls should not appear
+    assert 'BPF_HASH(write_count' not in program
+    assert 'trace_write_entry' not in program

--- a/tests/test_syscall_config.py
+++ b/tests/test_syscall_config.py
@@ -1,0 +1,37 @@
+import types, sys
+
+# Provide a stub for the bcc module so sysview imports without system dependencies
+bcc_stub = types.ModuleType('bcc')
+bcc_stub.BPF = object
+sys.modules.setdefault('bcc', bcc_stub)
+
+import sysview
+
+
+def test_merge_config_overrides_and_adds():
+    cfg = sysview.SyscallConfig()
+    user_cfg = {
+        'syscalls': {
+            'write': {'enabled': False, 'color': 99},
+            'newcall': {
+                'name': 'newcall',
+                'color': 10,
+                'color_def': 1,
+                'desc': 'test syscall',
+                'enabled': True,
+            },
+        }
+    }
+    cfg.merge_config(user_cfg)
+
+    # existing key overridden
+    assert cfg.syscalls['write']['enabled'] is False
+    assert cfg.syscalls['write']['color'] == 99
+
+    # new syscall added
+    assert 'newcall' in cfg.syscalls
+    assert cfg.syscalls['newcall']['name'] == 'newcall'
+
+    enabled = cfg.get_enabled_syscalls()
+    assert 'write' not in enabled  # disabled in user config
+    assert 'newcall' in enabled


### PR DESCRIPTION
## Summary
- add basic tests for SyscallConfig merging and BPF code generation
- stub `bcc` in tests so they can run without system dependencies
- document how to run the tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c26252d88328b4c3f275f921a060