### PR TITLE
Fix alias probe warning

### DIFF
--- a/sysview.py
+++ b/sysview.py
@@ -203,8 +203,10 @@ class SyscallMonitor:
                                 event=self.b.get_syscall_fnname(alias),
                                 fn_name=f"trace_{name}_entry",
                             )
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            print(
+                                f"Warning: Failed to attach alias {alias} for {name}: {e}"
+                            )
 
             except Exception as e:
                 print(f"Warning: Failed to attach probe for {name}: {e}")


### PR DESCRIPTION
## Summary
- log alias name when a kprobe fails to attach

## Testing
- `python3 -m py_compile sysview.py csview.py hview.py`


------
https://chatgpt.com/codex/tasks/task_e_6840c2614c308328b15533551342fcf3