### PR TITLE
Add root privilege checks

### DIFF
--- a/csview.py
+++ b/csview.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import time
 import curses
+import os
 from pathlib import Path
 from bcc import BPF
 
@@ -236,6 +237,13 @@ def tui(scr):
 
 
 # ────────── main ────────────────────────────────────────────────────────────
-if __name__ == "__main__":
+def main():
+    if os.geteuid() != 0:
+        print("This script must be run as root. Please run with sudo.")
+        return
     signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
     curses.wrapper(tui)
+
+
+if __name__ == "__main__":
+    main()

--- a/hview.py
+++ b/hview.py
@@ -7,6 +7,7 @@ import signal
 import time
 import sys
 import hashlib
+import os
 from bcc import BPF
 
 # ───── CLI ──────────────────────────────────────────────────────────
@@ -233,6 +234,13 @@ def tui(scr):
         time.sleep(0.03)
 
 
-if __name__ == "__main__":
+def main():
+    if os.geteuid() != 0:
+        print("This script must be run as root. Please run with sudo.")
+        return
     signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
     curses.wrapper(tui)
+
+
+if __name__ == "__main__":
+    main()

--- a/sysview.py
+++ b/sysview.py
@@ -592,6 +592,9 @@ def main_wrapper(stdscr, args):
 
 
 def main():
+    if os.geteuid() != 0:
+        print("This script must be run as root. Please run with sudo.")
+        return
     parser = argparse.ArgumentParser(
         description="Extensible Syscall Monitoring Tool"
     )


### PR DESCRIPTION
## Summary
- ensure `sysview.py`, `csview.py`, and `hview.py` exit when not run as root
- expose a `main()` entrypoint for `csview.py` and `hview.py` with the new check

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile sysview.py csview.py hview.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c2609c648328b772ccdf30f8fff3