### PR TITLE
Fix csview docstring

### DIFF
--- a/csview.py
+++ b/csview.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" hview.py — realtime eBPF heap-flame graph (bytes live per call-stack) """
+""" csview.py — realtime eBPF heap-flame graph (bytes live per call-stack) """
 
 import argparse
 import hashlib


### PR DESCRIPTION
## Summary
- correct filename reference in `csview.py`

## Testing
- `python3 -m py_compile csview.py hview.py sysview.py`


------
https://chatgpt.com/codex/tasks/task_e_6840c25f91fc8328b293261013aeed86