### PR TITLE
Add syscall config validation and category summary

### DIFF
--- a/sysview.py
+++ b/sysview.py
@@ -2,6 +2,7 @@
 
 import argparse
 import collections
+import copy
 import datetime
 import json
 import os
@@ -21,6 +22,7 @@ class SyscallConfig:
                 "color_def": curses.COLOR_GREEN,
                 "desc": "Writing to files/pipes",
                 "enabled": True,
+                "category": "file",
             },
             "read": {
                 "name": "read",
@@ -28,6 +30,7 @@ class SyscallConfig:
                 "color_def": curses.COLOR_CYAN,
                 "desc": "Reading from files/pipes",
                 "enabled": True,
+                "category": "file",
             },
             "open": {
                 "name": "open",
@@ -35,6 +38,7 @@ class SyscallConfig:
                 "color_def": curses.COLOR_YELLOW,
                 "desc": "Opening files",
                 "enabled": True,
+                "category": "file",
             },
             "close": {
                 "name": "close",
@@ -42,6 +46,7 @@ class SyscallConfig:
                 "color_def": curses.COLOR_RED,
                 "desc": "Closing file descriptors",
                 "enabled": True,
+                "category": "file",
             },
             "mmap": {
                 "name": "mmap",
@@ -49,6 +54,7 @@ class SyscallConfig:
                 "color_def": curses.COLOR_MAGENTA,
                 "desc": "Memory mapping",
                 "enabled": True,
+                "category": "memory",
             },
             "socket": {
                 "name": "socket",
@@ -56,6 +62,7 @@ class SyscallConfig:
                 "color_def": curses.COLOR_BLUE,
                 "desc": "Network socket operations",
                 "enabled": True,
+                "category": "network",
             },
             "poll": {
                 "name": "poll",
@@ -64,6 +71,7 @@ class SyscallConfig:
                 "desc": "I/O event notifications (poll/select/epoll)",
                 "enabled": True,
                 "aliases": ["select", "epoll_wait"],
+                "category": "file",
             },
             "futex": {
                 "name": "futex",
@@ -71,6 +79,7 @@ class SyscallConfig:
                 "color_def": 208,  # Orange
                 "desc": "Fast user-space locking",
                 "enabled": True,
+                "category": "synchronization",
             },
             "execve": {
                 "name": "execve",
@@ -78,30 +87,46 @@ class SyscallConfig:
                 "color_def": 85,  # Teal
                 "desc": "Execute programs",
                 "enabled": True,
+                "category": "process",
             },
         }
 
-        self.syscalls = self.default_syscalls.copy()
+        self.syscalls = copy.deepcopy(self.default_syscalls)
 
         if filename and os.path.exists(filename):
             try:
                 with open(filename, "r") as f:
                     user_config = json.load(f)
                     self.merge_config(user_config)
+            except ValueError as e:
+                raise ValueError(f"Invalid configuration file '{filename}': {e}")
             except Exception as e:
                 print(f"Error loading config file: {e}")
 
     def merge_config(self, user_config):
         """Merge user configuration with defaults"""
-        if "syscalls" in user_config:
-            for syscall_name, syscall_config in user_config[
-                "syscalls"
-            ].items():
-                if syscall_name in self.syscalls:
-                    for key, value in syscall_config.items():
-                        self.syscalls[syscall_name][key] = value
-                else:
-                    self.syscalls[syscall_name] = syscall_config
+        if not isinstance(user_config, dict):
+            raise ValueError("Config must be a dictionary")
+
+        syscalls = user_config.get("syscalls")
+        if syscalls is None:
+            return
+        if not isinstance(syscalls, dict):
+            raise ValueError("'syscalls' must be a dictionary")
+
+        for syscall_name, syscall_config in syscalls.items():
+            if not isinstance(syscall_config, dict):
+                raise ValueError(
+                    f"Configuration for syscall '{syscall_name}' must be a dictionary"
+                )
+
+            base_config = copy.deepcopy(self.syscalls.get(syscall_name, {}))
+            merged_config = {**base_config, **syscall_config}
+            if "name" not in merged_config:
+                merged_config["name"] = syscall_name
+
+            validated = self._validate_syscall_config(syscall_name, merged_config)
+            self.syscalls[syscall_name] = validated
 
     def get_enabled_syscalls(self):
         """Return only enabled syscalls"""
@@ -115,6 +140,48 @@ class SyscallConfig:
         """Save current configuration to file"""
         with open(filename, "w") as f:
             json.dump({"syscalls": self.syscalls}, f, indent=2)
+
+    def _validate_syscall_config(self, syscall_name, config):
+        required_fields = {
+            "name": str,
+            "color": int,
+            "desc": str,
+            "enabled": bool,
+        }
+
+        for field, expected_type in required_fields.items():
+            if field not in config:
+                raise ValueError(
+                    f"Missing required field '{field}' for syscall '{syscall_name}'"
+                )
+            if not isinstance(config[field], expected_type):
+                raise ValueError(
+                    f"Field '{field}' for syscall '{syscall_name}' must be of type "
+                    f"{expected_type.__name__}"
+                )
+
+        if "color_def" in config and not isinstance(config["color_def"], int):
+            raise ValueError(
+                f"Field 'color_def' for syscall '{syscall_name}' must be an integer"
+            )
+
+        if "aliases" in config:
+            aliases = config["aliases"]
+            if not isinstance(aliases, list) or not all(
+                isinstance(alias, str) for alias in aliases
+            ):
+                raise ValueError(
+                    f"Field 'aliases' for syscall '{syscall_name}' must be a list of strings"
+                )
+
+        category = config.get("category", "uncategorized")
+        if not isinstance(category, str):
+            raise ValueError(
+                f"Field 'category' for syscall '{syscall_name}' must be a string"
+            )
+        config["category"] = category
+
+        return config
 
 
 class SyscallMonitor:
@@ -437,115 +504,162 @@ class CursesDisplay:
             curses.A_BOLD,
         )
 
-        sorted_syscalls = sorted(
-            [
-                (
-                    syscall["name"],
-                    self.monitor.total_counts[syscall["name"]],
-                    self.monitor.peak_rates[syscall["name"]],
-                )
-                for syscall in self.monitor.syscalls
-            ],
-            key=lambda x: x[1],
-            reverse=True,
+        category_data = {}
+        for syscall in self.monitor.syscalls:
+            name = syscall["name"]
+            category = syscall.get("category", "uncategorized")
+            count = self.monitor.total_counts[name]
+            peak = self.monitor.peak_rates[name]
+
+            category_entry = category_data.setdefault(
+                category,
+                {
+                    "count": 0,
+                    "peak_rate": 0,
+                    "color": syscall.get("color"),
+                    "syscalls": [],
+                },
+            )
+            if category_entry.get("color") is None and syscall.get("color") is not None:
+                category_entry["color"] = syscall.get("color")
+
+            category_entry["count"] += count
+            category_entry["peak_rate"] += peak
+            category_entry["syscalls"].append(
+                {
+                    "name": name,
+                    "count": count,
+                    "peak": peak,
+                    "color": syscall.get("color", 0),
+                }
+            )
+
+        sorted_categories = sorted(
+            category_data.items(), key=lambda item: item[1]["count"], reverse=True
+        )
+
+        name_col_width = 16
+        count_col_width = 17
+        rate_num_width = 13
+        peak_num_width = 9
+
+        header_line = (
+            f"│ {'CATEGORY':<{name_col_width}} │ "
+            f"{'TOTAL CALLS':^{count_col_width}} │ "
+            f"{'AVG RATE (/s)':^{rate_num_width + 4}} │ "
+            f"{'PEAK RATE (/s)':^{peak_num_width + 4}} │"
+        )
+        divider_line = (
+            "├"
+            + "─" * (name_col_width + 2)
+            + "┼"
+            + "─" * (count_col_width + 2)
+            + "┼"
+            + "─" * (rate_num_width + 4)
+            + "┼"
+            + "─" * (peak_num_width + 4)
+            + "┤"
+        )
+        bottom_line = (
+            "└"
+            + "─" * (name_col_width + 2)
+            + "┴"
+            + "─" * (count_col_width + 2)
+            + "┴"
+            + "─" * (rate_num_width + 4)
+            + "┴"
+            + "─" * (peak_num_width + 4)
+            + "┘"
         )
 
         y_pos = 5
-        stdscr.addstr(
-            y_pos,
-            0,
-            "│ SYSCALL  │    TOTAL CALLS    │  RATE (per sec) │  PEAK RATE  │",
-            curses.A_BOLD,
-        )
+        stdscr.addstr(y_pos, 0, header_line, curses.A_BOLD)
         y_pos += 1
-        stdscr.addstr(
-            y_pos,
-            0,
-            (
-                "├──────────┼───────────────────┼"
-                "─────────────────┼─────────────┤"
-            ),
-            curses.A_NORMAL,
-        )
+        stdscr.addstr(y_pos, 0, divider_line, curses.A_NORMAL)
         y_pos += 1
 
-        for name, count, peak in sorted_syscalls:
-            for syscall in self.monitor.syscalls:
-                if syscall["name"] == name:
-                    color = syscall["color"]
-                    break
-
-            avg_rate = count / runtime if runtime > 0 else 0
-
-            syscall_line = (
-                f"│ {name:8s} │ {self.format_number(count):>17s} │ "
-                f"{avg_rate:13.2f}/s │ {peak:9.2f}/s │"
+        for index, (category, stats) in enumerate(sorted_categories):
+            avg_rate = stats["count"] / runtime if runtime > 0 else 0
+            category_line = (
+                f"│ {category:<{name_col_width}} │ "
+                f"{self.format_number(stats['count']):>{count_col_width}} │ "
+                f"{avg_rate:>{rate_num_width}.2f}/s │ "
+                f"{stats['peak_rate']:>{peak_num_width}.2f}/s │"
             )
-            stdscr.addstr(y_pos, 0, syscall_line, curses.color_pair(color))
+            stdscr.addstr(y_pos, 0, category_line, curses.A_BOLD)
             y_pos += 1
 
-        total_count = sum(self.monitor.total_counts.values())
-        total_rate = total_count / runtime if runtime > 0 else 0
-        max_peak = max(self.monitor.peak_rates.values())
+            syscall_entries = sorted(
+                stats["syscalls"], key=lambda entry: entry["count"], reverse=True
+            )
+            for entry in syscall_entries:
+                label = f"  {entry['name']}"
+                avg_rate = entry["count"] / runtime if runtime > 0 else 0
+                syscall_line = (
+                    f"│ {label:<{name_col_width}} │ "
+                    f"{self.format_number(entry['count']):>{count_col_width}} │ "
+                    f"{avg_rate:>{rate_num_width}.2f}/s │ "
+                    f"{entry['peak']:>{peak_num_width}.2f}/s │"
+                )
+                stdscr.addstr(
+                    y_pos,
+                    0,
+                    syscall_line,
+                    curses.color_pair(entry["color"]),
+                )
+                y_pos += 1
 
-        stdscr.addstr(
-            y_pos,
-            0,
-            "├──────────┼───────────────────┼─────────────────┼─────────────┤",
-            curses.A_NORMAL,
+            if index < len(sorted_categories) - 1:
+                stdscr.addstr(y_pos, 0, divider_line, curses.A_NORMAL)
+                y_pos += 1
+
+        total_count = sum(stats["count"] for stats in category_data.values())
+        total_rate = total_count / runtime if runtime > 0 else 0
+        max_peak = max(
+            (stats["peak_rate"] for stats in category_data.values()),
+            default=0,
         )
+
+        stdscr.addstr(y_pos, 0, divider_line, curses.A_NORMAL)
         y_pos += 1
         total_line = (
-            f"│ TOTAL    │ {self.format_number(total_count):>17s} │ "
-            f"{total_rate:13.2f}/s │ {max_peak:9.2f}/s │"
+            f"│ {'TOTAL':<{name_col_width}} │ "
+            f"{self.format_number(total_count):>{count_col_width}} │ "
+            f"{total_rate:>{rate_num_width}.2f}/s │ "
+            f"{max_peak:>{peak_num_width}.2f}/s │"
         )
         stdscr.addstr(y_pos, 0, total_line, curses.A_BOLD)
         y_pos += 1
-
-        stdscr.addstr(
-            y_pos,
-            0,
-            (
-                "└──────────┴───────────────────┴"
-                "─────────────────┴─────────────┘"
-            ),
-            curses.A_BOLD,
-        )
+        stdscr.addstr(y_pos, 0, bottom_line, curses.A_BOLD)
         y_pos += 2
 
         if total_count > 0:
-            stdscr.addstr(y_pos, 0, "Percentage breakdown:", curses.A_BOLD)
+            stdscr.addstr(y_pos, 0, "Category percentage breakdown:", curses.A_BOLD)
             y_pos += 1
 
             bar_start = 40
             bar_width = 55
 
-            for i, (name, count, _) in enumerate(sorted_syscalls):
-                if count > 0:
-                    for syscall in self.monitor.syscalls:
-                        if syscall["name"] == name:
-                            color = syscall["color"]
-                            break
+            for category, stats in sorted_categories:
+                if stats["count"] <= 0:
+                    continue
 
-                    percent = (count / total_count) * 100
-                    bar_len = int((percent / 100) * bar_width)
+                percent = (stats["count"] / total_count) * 100
+                bar_len = int((percent / 100) * bar_width)
 
-                    pct_line = (
-                        f"{name:8s}: {percent:5.1f}% "
-                        f"({self.format_number(count)} calls) "
-                    )
-                    stdscr.addstr(y_pos, 0, pct_line)
+                pct_line = (
+                    f"{category:<{name_col_width}}: {percent:5.1f}% "
+                    f"({self.format_number(stats['count'])} calls) "
+                )
+                stdscr.addstr(y_pos, 0, pct_line)
 
-                    for j in range(bar_len):
-                        if bar_start + j < max_x:
-                            stdscr.addch(
-                                y_pos,
-                                bar_start + j,
-                                "█",
-                                curses.color_pair(color),
-                            )
+                color = stats.get("color") or 0
+                attr = curses.color_pair(color) if color else curses.A_NORMAL
+                for j in range(bar_len):
+                    if bar_start + j < max_x:
+                        stdscr.addch(y_pos, bar_start + j, "█", attr)
 
-                    y_pos += 1
+                y_pos += 1
 
         y_pos += 1
         if y_pos < max_y:

--- a/tests/test_syscall_config.py
+++ b/tests/test_syscall_config.py
@@ -1,5 +1,7 @@
 import types, sys
 
+import pytest
+
 # Provide a stub for the bcc module so sysview imports without system dependencies
 bcc_stub = types.ModuleType('bcc')
 bcc_stub.BPF = object
@@ -35,3 +37,24 @@ def test_merge_config_overrides_and_adds():
     enabled = cfg.get_enabled_syscalls()
     assert 'write' not in enabled  # disabled in user config
     assert 'newcall' in enabled
+
+
+def test_merge_config_requires_fields():
+    cfg = sysview.SyscallConfig()
+
+    with pytest.raises(ValueError):
+        cfg.merge_config({'syscalls': {'broken': {'color': 1}}})
+
+
+def test_merge_config_validates_aliases_type():
+    cfg = sysview.SyscallConfig()
+
+    with pytest.raises(ValueError):
+        cfg.merge_config({'syscalls': {'read': {'aliases': 'not-a-list'}}})
+
+
+def test_enabled_syscalls_include_category():
+    cfg = sysview.SyscallConfig()
+    enabled = cfg.get_enabled_syscalls()
+
+    assert enabled['read']['category'] == 'file'


### PR DESCRIPTION
## Summary
- add type validation for syscall configuration entries and propagate category metadata
- update summary view to aggregate totals by category while preserving per-syscall detail
- extend tests to cover config validation and ensure categories surface in enabled syscalls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d420eb08008328baf2fa17179c72ce