### PR TITLE
Track per-entity syscall counts

### DIFF
--- a/sysview.py
+++ b/sysview.py
@@ -118,11 +118,12 @@ class SyscallConfig:
 
 
 class SyscallMonitor:
-    def __init__(self, config, interval=1, history_size=60):
+    def __init__(self, config, interval=1, history_size=60, group_by="pid"):
         self.config = config
         self.sample_interval = interval
         self.history_size = history_size
         self.start_time = time.time()
+        self.group_by = group_by
 
         self.initialize_data_structures()
 
@@ -138,6 +139,7 @@ class SyscallMonitor:
         self.last_counts = {}
         self.total_counts = {}
         self.peak_rates = {}
+        self.entity_counts = {}
 
         for name, config in self.config.get_enabled_syscalls().items():
             self.syscalls.append(config)
@@ -147,12 +149,13 @@ class SyscallMonitor:
             self.last_counts[name] = 0
             self.total_counts[name] = 0
             self.peak_rates[name] = 0
+            self.entity_counts[name] = {}
 
     def generate_bpf_program(self):
         """Dynamically generate BPF program based on enabled syscalls"""
         bpf_header = """
         #include <uapi/linux/ptrace.h>
-        
+
         // Define BPF maps to store counts for different syscalls
         """
 
@@ -161,27 +164,35 @@ class SyscallMonitor:
 
         enabled_syscalls = self.config.get_enabled_syscalls()
         for name in enabled_syscalls:
-            bpf_maps += f"BPF_HASH({name}_count, u32, u64);\n"
+            bpf_maps += f"BPF_HASH({name}_count, u64, u64);\n"
 
         for name, config in enabled_syscalls.items():
+            if getattr(self, "group_by", "pid") == "pid":
+                key_assign = "key = id >> 32;"
+            else:
+                key_assign = "key = id;"
             function_template = """
             // Track {name} syscalls
             int trace_{name}_entry(struct pt_regs *ctx) {{
-                u64 counter = 0;
-                u32 key = 0;
-            
+                u64 id = bpf_get_current_pid_tgid();
+                u64 key = 0;
+                u64 init = 1;
+
+                {key_assign}
+
                 u64 *count = {name}_count.lookup(&key);
                 if (count) {{
-                    counter = *count;
+                    (*count)++;
+                }} else {{
+                    {name}_count.update(&key, &init);
                 }}
-            
-                counter++;
-                {name}_count.update(&key, &counter);
-            
+
                 return 0;
             }}
             """
-            bpf_functions += function_template.format(name=name)
+            bpf_functions += function_template.format(
+                name=name, key_assign=key_assign
+            )
 
         return bpf_header + bpf_maps + bpf_functions
 
@@ -211,12 +222,47 @@ class SyscallMonitor:
             except Exception as e:
                 print(f"Warning: Failed to attach probe for {name}: {e}")
 
-    def get_count(self, name):
-        """Get current count for a syscall"""
+    def get_counts(self, name):
+        """Get current per-entity counts for a syscall"""
         count_map = self.b.get_table(f"{name}_count")
+        counts: dict[int, int] = {}
         for k, v in count_map.items():
-            return v.value
-        return 0
+            counts[int(k.value)] = v.value
+        return counts
+
+    def entity_id_to_components(self, entity_id: int) -> tuple[int, int]:
+        """Return (pid, tid) tuple derived from the entity identifier."""
+        if self.group_by == "pid":
+            return entity_id, entity_id
+        pid = entity_id >> 32
+        tid = entity_id & 0xFFFFFFFF
+        return pid, tid
+
+    def format_entity_label(self, entity_id: int) -> str:
+        """Generate a human-friendly label for a workload."""
+        pid, tid = self.entity_id_to_components(entity_id)
+
+        if self.group_by == "pid":
+            comm_path = f"/proc/{pid}/comm"
+            label = f"pid {pid}"
+        else:
+            comm_path = f"/proc/{pid}/task/{tid}/comm"
+            label = f"tid {tid} (pid {pid})"
+
+        try:
+            with open(comm_path, "r") as comm_file:
+                name = comm_file.read().strip()
+                if name:
+                    label = f"{label} [{name}]"
+        except OSError:
+            pass
+
+        return label
+
+    def get_grouping_description(self) -> str:
+        if self.group_by == "pid":
+            return "per-process (PID)"
+        return "per-thread (TID)"
 
     def update_counts(self):
         """Update all syscall counts"""
@@ -225,11 +271,13 @@ class SyscallMonitor:
         for syscall in self.syscalls:
             name = syscall["name"]
 
-            current_count = self.get_count(name)
-            self.total_counts[name] = current_count
+            counts = self.get_counts(name)
+            total = sum(counts.values())
+            self.total_counts[name] = total
+            self.entity_counts[name] = counts
 
             rate = (
-                current_count - self.last_counts[name]
+                total - self.last_counts[name]
             ) / self.sample_interval
             current_rates[name] = rate
 
@@ -237,7 +285,7 @@ class SyscallMonitor:
                 self.peak_rates[name] = rate
 
             self.history[name].append(rate)
-            self.last_counts[name] = current_count
+            self.last_counts[name] = total
 
         return current_rates
 
@@ -430,8 +478,15 @@ class CursesDisplay:
             f"│ Duration:   {self.format_time(runtime):<19s} │",
             curses.A_NORMAL,
         )
+        grouping_desc = self.monitor.get_grouping_description()
         stdscr.addstr(
             4,
+            0,
+            f"│ Grouping:   {grouping_desc:<19s} │",
+            curses.A_NORMAL,
+        )
+        stdscr.addstr(
+            5,
             0,
             "├──────────────────────────────────────────────────────────────┤",
             curses.A_BOLD,
@@ -450,7 +505,7 @@ class CursesDisplay:
             reverse=True,
         )
 
-        y_pos = 5
+        y_pos = 6
         stdscr.addstr(
             y_pos,
             0,
@@ -501,6 +556,55 @@ class CursesDisplay:
         )
         stdscr.addstr(y_pos, 0, total_line, curses.A_BOLD)
         y_pos += 1
+
+        entity_totals = collections.Counter()
+        per_syscall_top = {}
+        for syscall in self.monitor.syscalls:
+            name = syscall["name"]
+            counts = self.monitor.entity_counts.get(name, {})
+            if counts:
+                per_syscall_top[name] = max(counts.items(), key=lambda kv: kv[1])
+            entity_totals.update(counts)
+
+        if entity_totals:
+            y_pos += 1
+            stdscr.addstr(
+                y_pos,
+                0,
+                "├────────────────────────── Top Workloads ─────────────────────┤",
+                curses.A_BOLD,
+            )
+            y_pos += 1
+
+            top_entities = entity_totals.most_common(5)
+            for entity_id, count in top_entities:
+                label = self.monitor.format_entity_label(entity_id)
+                percent = (count / total_count * 100) if total_count else 0
+                line = (
+                    f"│ {label:<45.45s} {self.format_number(count):>12s}"
+                    f" ({percent:5.1f}%) │"
+                )
+                stdscr.addstr(y_pos, 0, line)
+                y_pos += 1
+
+            if per_syscall_top:
+                y_pos += 1
+                stdscr.addstr(
+                    y_pos,
+                    0,
+                    "├─────────────────────── Per-syscall leaders ──────────────────┤",
+                    curses.A_BOLD,
+                )
+                y_pos += 1
+
+                for name, (entity_id, count) in per_syscall_top.items():
+                    label = self.monitor.format_entity_label(entity_id)
+                    line = (
+                        f"│ {name:8s} → {label:<33.33s}"
+                        f" {self.format_number(count):>12s} │"
+                    )
+                    stdscr.addstr(y_pos, 0, line)
+                    y_pos += 1
 
         stdscr.addstr(
             y_pos,
@@ -561,6 +665,7 @@ def main_wrapper(stdscr, args):
         config,
         interval=args.interval,
         history_size=args.history,
+        group_by=args.group_by,
     )
     display = CursesDisplay(monitor)
 
@@ -582,8 +687,16 @@ def main_wrapper(stdscr, args):
                             "start_time": monitor.start_time,
                             "end_time": time.time(),
                             "duration": monitor.get_runtime(),
+                            "group_by": monitor.group_by,
                             "total_counts": monitor.total_counts,
                             "peak_rates": monitor.peak_rates,
+                            "entity_counts": {
+                                name: {
+                                    str(entity): count
+                                    for entity, count in entities.items()
+                                }
+                                for name, entities in monitor.entity_counts.items()
+                            },
                         },
                         f,
                         indent=2,
@@ -618,6 +731,12 @@ def main():
     parser.add_argument("--output", "-o", help="Save results to file (JSON)")
     parser.add_argument(
         "--generate-config", "-g", help="Generate default config file and exit"
+    )
+    parser.add_argument(
+        "--group-by",
+        choices=["pid", "tid"],
+        default="pid",
+        help="Aggregate counts per process (pid) or per thread (tid)",
     )
 
     args = parser.parse_args()

--- a/tests/test_bpf_generation.py
+++ b/tests/test_bpf_generation.py
@@ -11,6 +11,7 @@ import sysview
 def _create_monitor(cfg):
     monitor = sysview.SyscallMonitor.__new__(sysview.SyscallMonitor)
     monitor.config = cfg
+    monitor.group_by = "pid"
     return monitor
 
 
@@ -26,7 +27,20 @@ def test_generate_bpf_program_only_enabled_syscalls():
     # Should contain BPF map and function for 'read'
     assert 'BPF_HASH(read_count' in program
     assert 'trace_read_entry' in program
+    assert 'bpf_get_current_pid_tgid' in program
+    assert 'key = id >> 32;' in program
 
     # Disabled syscalls should not appear
     assert 'BPF_HASH(write_count' not in program
     assert 'trace_write_entry' not in program
+
+
+def test_generate_bpf_program_tid_grouping():
+    cfg = sysview.SyscallConfig()
+    monitor = _create_monitor(cfg)
+    monitor.group_by = "tid"
+
+    program = sysview.SyscallMonitor.generate_bpf_program(monitor)
+
+    assert 'key = id;' in program
+    assert 'key = id >> 32;' not in program


### PR DESCRIPTION
## Summary
- add a configurable grouping mode to collect syscall counters per process or per thread
- update the generated eBPF program and userland aggregation to maintain per-entity counts and surface the busiest workloads in the summary view
- persist grouping metadata and per-entity counts in the JSON export and cover the new behaviour with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d420e48f708328abe4827113a5f536